### PR TITLE
Deal with attributes without options

### DIFF
--- a/pymee/model.py
+++ b/pymee/model.py
@@ -4,7 +4,7 @@ from urllib.parse import unquote
 
 class HomeeAttributeOptions:
     def __init__(self, attributeOptions):
-        self._data = attributeOptions
+        self._data = attributeOptions if attributeOptions is not None else []
 
     @property
     def can_observe(self) -> list:


### PR DESCRIPTION
If trying to access options if the attribute has none leads to an error. This fixes it.